### PR TITLE
Support relative direct method in mach-o image on linux platform

### DIFF
--- a/Sources/MachOObjCSection/Extension/DyldCacheLoaded+.swift
+++ b/Sources/MachOObjCSection/Extension/DyldCacheLoaded+.swift
@@ -8,6 +8,16 @@
 
 import MachOKit
 
+#if !canImport(Darwin)
+extension DyldCacheLoaded {
+    // FIXME: fallback for linux
+    public static var current: DyldCacheLoaded? {
+        return nil
+    }
+}
+#endif
+
+
 extension DyldCacheLoaded {
     var headerOptimizationRO64: ObjCHeaderOptimizationRO64? {
         guard cpu.is64Bit else {

--- a/Sources/MachOObjCSection/Model/Method/ObjCMethod.swift
+++ b/Sources/MachOObjCSection/Model/Method/ObjCMethod.swift
@@ -99,12 +99,23 @@ extension ObjCMethod {
 
     init(_ relativeDirect: RelativeDirect, at pointer: UnsafeRawPointer) {
 #if !canImport(ObjectiveC)
-        fatalError("Unsupported Platform")
+        guard let cache: DyldCacheLoaded = .current else {
+            fatalError("Unsupported Platform")
+        }
+        let base: UnsafeRawPointer
+        if let objcOptimization = cache.objcOptimization {
+            base = objcOptimization.relativeMethodSelectorBaseAddress(in: cache)
+        } else if let objcOptimization = cache.oldObjcOptimization {
+            base = objcOptimization.relativeMethodSelectorBaseAddress(in: cache)
+        } else {
+            fatalError("Unsupported Platform")
+        }
 #else
         let base = unsafeBitCast(
             NSSelectorFromString("🤯"),
             to: UnsafeRawPointer.self
         )
+#endif
 
         self.init(
             name: .init(
@@ -124,7 +135,6 @@ extension ObjCMethod {
                 )
             )
         )
-#endif
     }
 }
 


### PR DESCRIPTION
In most cases mach-o images are never loaded in memory on linux platforms.

However, for compatibility reasons, an implementation has been made.