### PR TITLE
Return protocols and classes paired with their defining Mach-O files

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/MachOKit.git",
       "state" : {
-        "revision" : "62d22e1ecef3dda702c039f03dd83f674ad59bfc",
-        "version" : "0.30.0"
+        "revision" : "753461938fafdcdbcd19b68b34b137dc37367d22",
+        "version" : "0.34.0"
+      }
+    },
+    {
+      "identity" : "swift-fileio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/p-x9/swift-fileio.git",
+      "state" : {
+        "revision" : "23349fe1eb23c6ca2876d461a46ff60c0fa92f9c",
+        "version" : "0.9.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/p-x9/MachOKit.git", from: "0.30.0"),
+        .package(url: "https://github.com/p-x9/MachOKit.git", from: "0.34.0"),
         .package(url: "https://github.com/p-x9/swift-objc-dump.git", from: "0.7.0")
     ],
     targets: [

--- a/Sources/MachOObjCSection/Extension/DyldCache+.swift
+++ b/Sources/MachOObjCSection/Extension/DyldCache+.swift
@@ -115,3 +115,14 @@ extension DyldCache {
         return nil
     }
 }
+
+extension DyldCache {
+    func machO(containing unslidAddress: UInt64) -> MachOFile? {
+        for machO in self.machOFiles() {
+            if machO.contains(unslidAddress: unslidAddress) {
+                return machO
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/MachOObjCSection/Extension/DyldCacheLoaded+.swift
+++ b/Sources/MachOObjCSection/Extension/DyldCacheLoaded+.swift
@@ -99,3 +99,23 @@ extension DyldCacheLoaded {
         return nil
     }
 }
+
+extension DyldCacheLoaded {
+    func machO(containing ptr: UnsafeRawPointer) -> MachOImage? {
+        for machO in machOImages() {
+            if machO.contains(ptr: ptr) {
+                return machO
+            }
+        }
+        return nil
+    }
+
+    func machO(containing unslidAddress: UInt64) -> MachOImage? {
+        for machO in self.machOImages() {
+            if machO.contains(unslidAddress: unslidAddress) {
+                return machO
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/MachOObjCSection/Model/Protocol/ObjCProtocolList64.swift
+++ b/Sources/MachOObjCSection/Model/Protocol/ObjCProtocolList64.swift
@@ -26,13 +26,13 @@ public struct ObjCProtocolList64: ObjCProtocolListProtocol {
 extension ObjCProtocolList64 {
     public func protocols(
         in machO: MachOImage
-    ) -> [ObjCProtocol]? {
+    ) -> [(MachOImage, ObjCProtocol)]? {
         _readProtocols(in: machO, pointerType: UInt64.self)
     }
 
     public func protocols(
         in machO: MachOFile
-    ) -> [ObjCProtocol]? {
+    ) -> [(MachOFile, ObjCProtocol)]? {
         guard !isListOfLists else {
             assertionFailure()
             return nil
@@ -63,6 +63,8 @@ extension ObjCProtocolList64 {
                 let offset = machO.fileOffset(of: $0) + numericCast(headerStartOffset)
                 var resolvedOffset = offset
 
+                var targetMachO = machO
+
                 var fileHandle = machO.fileHandle
 
                 if let (_cache, _offset) = machO.cacheAndFileOffset(
@@ -70,16 +72,23 @@ extension ObjCProtocolList64 {
                 ) {
                     resolvedOffset = _offset
                     fileHandle = _cache.fileHandle
+
+                    let unslidAddress = offset + _cache.mainCacheHeader.sharedRegionStart
+                    if !targetMachO.contains(unslidAddress: unslidAddress),
+                       let machO = _cache.machO(containing: unslidAddress) {
+                        targetMachO = machO
+                    }
                 }
 
                 let layout: ObjCProtocol64.Layout = fileHandle.read(
                     offset:  numericCast(resolvedOffset),
                     swapHandler: { _ in }
                 )
-                return .init(
+                let `protocol`: ObjCProtocol = .init(
                     layout: layout,
                     offset: numericCast(offset) - machO.headerStartOffset
                 )
+                return (targetMachO, `protocol`)
             }
     }
 }

--- a/Sources/MachOObjCSection/Support/ObjCDump.swift
+++ b/Sources/MachOObjCSection/Support/ObjCDump.swift
@@ -3,7 +3,7 @@
 //
 //
 //  Created by p-x9 on 2024/09/28
-//  
+//
 //
 
 import Foundation
@@ -73,7 +73,7 @@ extension ObjCProtocolProtocol {
         let protocolList = protocolList(in: machO)
         let protocols = protocolList?
             .protocols(in: machO)?
-            .compactMap { $0.info(in: machO) } ?? []
+            .compactMap { $1.info(in: $0) } ?? []
 
         let classPropertiesList = classPropertyList(in: machO)
         let classProperties = classPropertiesList?
@@ -129,7 +129,7 @@ extension ObjCProtocolProtocol {
         let protocolList = protocolList(in: machO)
         let protocols = protocolList?
             .protocols(in: machO)?
-            .compactMap { $0.info(in: machO) } ?? []
+            .compactMap { $1.info(in: $0) } ?? []
 
         let classPropertiesList = classPropertyList(in: machO)
         let classProperties = classPropertiesList?
@@ -182,21 +182,21 @@ extension ObjCProtocolProtocol {
 extension ObjCClassProtocol {
     public func info(in machO: MachOFile) -> ObjCClassInfo? {
         guard let data = classROData(in: machO),
-              let meta = metaClass(in: machO),
-              let metaData = meta.classROData(in: machO),
+              let (targetMachO, meta) = metaClass(in: machO),
+              let metaData = meta.classROData(in: targetMachO),
               let name = data.name(in: machO) else {
             return nil
         }
         let protocolList = data.protocolList(in: machO)
         var protocols = protocolList?
             .protocols(in: machO)?
-            .compactMap { $0.info(in: machO) } ?? []
+            .compactMap { $1.info(in: $0) } ?? []
         if let relative = data.protocolRelativeListList(in: machO) {
             protocols = relative.lists(in: machO)
                 .filter({ $0.0.imagePath == machO.imagePath })
                 .flatMap { machO, list in
                     list.protocols(in: machO)?
-                        .compactMap { $0.info(in: machO) } ?? []
+                        .compactMap { $1.info(in: $0) } ?? []
                 }
         }
 
@@ -233,26 +233,26 @@ extension ObjCClassProtocol {
         }
 
         // Meta
-        let classPropertiesList = metaData.propertyList(in: machO)
+        let classPropertiesList = metaData.propertyList(in: targetMachO)
         var classProperties = classPropertiesList?
-            .properties(in: machO)
+            .properties(in: targetMachO)
             .compactMap { $0.info(isClassProperty: true) } ?? []
-        if let relative = metaData.propertyRelativeListList(in: machO) {
-            classProperties = relative.lists(in: machO)
-                .filter { $0.0.imagePath == machO.imagePath }
+        if let relative = metaData.propertyRelativeListList(in: targetMachO) {
+            classProperties = relative.lists(in: targetMachO)
+                .filter { $0.0.imagePath == targetMachO.imagePath }
                 .flatMap { machO, list in
                     list.properties(in: machO)
                         .compactMap { $0.info(isClassProperty: true) }
                 }
         }
 
-        let classMethodsList = metaData.methodList(in: machO)
+        let classMethodsList = metaData.methodList(in: targetMachO)
         var classMethods = classMethodsList?
-            .methods(in: machO)?
+            .methods(in: targetMachO)?
             .compactMap { $0.info(isClassMethod: true) } ?? []
-        if let relative = metaData.methodRelativeListList(in: machO) {
-            classMethods = relative.lists(in: machO)
-                .filter({ $0.0.imagePath == machO.imagePath })
+        if let relative = metaData.methodRelativeListList(in: targetMachO) {
+            classMethods = relative.lists(in: targetMachO)
+                .filter({ $0.0.imagePath == targetMachO.imagePath })
                 .flatMap { machO, list in
                     list.methods(in: machO)?
                         .compactMap { $0.info(isClassMethod: true) } ?? []
@@ -277,7 +277,7 @@ extension ObjCClassProtocol {
     }
 
     public func info(in machO: MachOImage) -> ObjCClassInfo? {
-        guard let meta = metaClass(in: machO) else {
+        guard let (targetMachO, meta) = metaClass(in: machO) else {
             return nil
         }
 
@@ -299,13 +299,13 @@ extension ObjCClassProtocol {
             return nil
         }
 
-        if let _data = meta.classROData(in: machO) {
+        if let _data = meta.classROData(in: targetMachO) {
             metaData = _data
-        } else if let rw = meta.classRWData(in: machO) {
-            if let _data = rw.classROData(in: machO) {
+        } else if let rw = meta.classRWData(in: targetMachO) {
+            if let _data = rw.classROData(in: targetMachO) {
                 metaData = _data
-            } else if let ext = rw.ext(in: machO),
-                      let _data = ext.classROData(in: machO) {
+            } else if let ext = rw.ext(in: targetMachO),
+                      let _data = ext.classROData(in: targetMachO) {
                 metaData = _data
             } else {
                 return nil
@@ -321,13 +321,13 @@ extension ObjCClassProtocol {
         let protocolList = data.protocolList(in: machO)
         var protocols = protocolList?
             .protocols(in: machO)?
-            .compactMap { $0.info(in: machO) } ?? []
+            .compactMap { $1.info(in: $0) } ?? []
         if let relative = data.protocolRelativeListList(in: machO) {
             protocols = relative.lists(in: machO)
-                .filter({ $0.0.path == machO.path })
+                .filter({ $0.0.ptr == machO.ptr })
                 .flatMap { machO, list in
                     list.protocols(in: machO)?
-                        .compactMap { $0.info(in: machO) } ?? []
+                        .compactMap { $1.info(in: $0) } ?? []
                 }
         }
 
@@ -364,26 +364,26 @@ extension ObjCClassProtocol {
         }
 
         // Meta
-        let classPropertiesList = metaData.propertyList(in: machO)
+        let classPropertiesList = metaData.propertyList(in: targetMachO)
         var classProperties = classPropertiesList?
-            .properties(in: machO)
+            .properties(in: targetMachO)
             .compactMap { $0.info(isClassProperty: true) } ?? []
-        if let relative = metaData.propertyRelativeListList(in: machO) {
-            classProperties = relative.lists(in: machO)
-                .filter { $0.0.ptr == machO.ptr }
+        if let relative = metaData.propertyRelativeListList(in: targetMachO) {
+            classProperties = relative.lists(in: targetMachO)
+                .filter { $0.0.ptr == targetMachO.ptr }
                 .flatMap { machO, list in
                     list.properties(in: machO)
                         .compactMap { $0.info(isClassProperty: true) }
                 }
         }
 
-        let classMethodsList = metaData.methodList(in: machO)
+        let classMethodsList = metaData.methodList(in: targetMachO)
         var classMethods = classMethodsList?
-            .methods(in: machO)
+            .methods(in: targetMachO)
             .compactMap { $0.info(isClassMethod: true) } ?? []
-        if let relative = metaData.methodRelativeListList(in: machO) {
-            classMethods = relative.lists(in: machO)
-                .filter({ $0.0.ptr == machO.ptr })
+        if let relative = metaData.methodRelativeListList(in: targetMachO) {
+            classMethods = relative.lists(in: targetMachO)
+                .filter({ $0.0.ptr == targetMachO.ptr })
                 .flatMap { machO, list in
                     list.methods(in: machO)
                         .compactMap { $0.info(isClassMethod: true) }
@@ -419,7 +419,7 @@ extension ObjCCategoryProtocol {
         let protocolList = protocolList(in: machO)
         let protocols = protocolList?
             .protocols(in: machO)?
-            .compactMap { $0.info(in: machO) } ?? []
+            .compactMap { $1.info(in: $0) } ?? []
 
         // Instance
         let propertiesList = instancePropertyList(in: machO)
@@ -463,7 +463,7 @@ extension ObjCCategoryProtocol {
         let protocolList = protocolList(in: machO)
         let protocols = protocolList?
             .protocols(in: machO)?
-            .compactMap { $0.info(in: machO) } ?? []
+            .compactMap { $1.info(in: $0) } ?? []
 
         // Instance
         let propertiesList = instancePropertyList(in: machO)


### PR DESCRIPTION
When a super class, category class, or compliant protocol is read from a mach-o in the Dyld cache, 
it may refer to something defined in a different mach-O file than the mach-o that contains itself.

