### PR TITLE
Lazily initialize and reuse file handles per owner instance.

### DIFF
--- a/Sources/MachOObjCSection/Extension/DyldCache+.swift
+++ b/Sources/MachOObjCSection/Extension/DyldCache+.swift
@@ -14,13 +14,24 @@ internal import FileIO
 @_implementationOnly import FileIO
 #endif
 
+extension FileHandleHolder<DyldCache, DyldCache.File> {
+    fileprivate static let shared: FileHandleHolder<Owner, File> = .init()
+}
+
 extension DyldCache {
     internal typealias File = MemoryMappedFile
 
     var fileHandle: File {
-        try! .open(url: url, isWritable: false)
+        FileHandleHolder.shared.fileHandle(
+            for: self,
+            initialize: {
+                try! .open(url: url, isWritable: false)
+            }
+        )
     }
+}
 
+extension DyldCache {
     var fileStartOffset: UInt64 {
         numericCast(
             header.sharedRegionStart - mainCacheHeader.sharedRegionStart

--- a/Sources/MachOObjCSection/Extension/FullDyldCache+.swift
+++ b/Sources/MachOObjCSection/Extension/FullDyldCache+.swift
@@ -14,23 +14,32 @@ internal import FileIO
 @_implementationOnly import FileIO
 #endif
 
+extension FileHandleHolder<FullDyldCache, FullDyldCache.File> {
+    fileprivate static let shared: FileHandleHolder<Owner, File> = .init()
+}
+
 extension FullDyldCache {
     internal typealias File = ConcatenatedMemoryMappedFile
 
     var fileHandle: File {
-        let mainCache = try! DyldCache(url: url)
+        FileHandleHolder.shared.fileHandle(
+            for: self,
+            initialize: {
+                let mainCache = try! DyldCache(url: url)
 
-        let subCacheSuffixes = mainCache.subCaches?.map {
-            $0.fileSuffix
-        } ?? []
-        var urls = [url]
-        urls += subCacheSuffixes.map {
-            URL(fileURLWithPath: url.path + $0)
-        }
+                let subCacheSuffixes = mainCache.subCaches?.map {
+                    $0.fileSuffix
+                } ?? []
+                var urls = [url]
+                urls += subCacheSuffixes.map {
+                    URL(fileURLWithPath: url.path + $0)
+                }
 
-        return try! .open(
-            urls: urls,
-            isWritable: false
+                return try! .open(
+                    urls: urls,
+                    isWritable: false
+                )
+            }
         )
     }
 }

--- a/Sources/MachOObjCSection/Extension/MachOFile+.swift
+++ b/Sources/MachOObjCSection/Extension/MachOFile+.swift
@@ -14,11 +14,20 @@ internal import FileIO
 @_implementationOnly import FileIO
 #endif
 
+extension FileHandleHolder<MachOFile, MachOFile.File> {
+    fileprivate static let shared: FileHandleHolder<Owner, File> = .init()
+}
+
 extension MachOFile {
     internal typealias File = MemoryMappedFile
 
     var fileHandle: File {
-        try! .open(url: url, isWritable: false)
+        FileHandleHolder.shared.fileHandle(
+            for: self,
+            initialize: {
+                try! .open(url: url, isWritable: false)
+            }
+        )
     }
 }
 

--- a/Sources/MachOObjCSection/Util/FileHandleHolder.swift
+++ b/Sources/MachOObjCSection/Util/FileHandleHolder.swift
@@ -1,0 +1,47 @@
+//
+//  FileHandleHolder.swift
+//  MachOObjCSection
+//
+//  Created by p-x9 on 2026/02/09
+//  
+//
+
+import Foundation
+#if compiler(>=6.0) || (compiler(>=5.10) && hasFeature(AccessLevelOnImport))
+internal import FileIO
+#else
+@_implementationOnly import FileIO
+#endif
+
+internal final class FileHandleHolder<
+    Owner: AnyObject,
+    File: FileIOProtocol & AnyObject
+>: @unchecked Sendable {
+    private let lock: NSRecursiveLock = .init()
+
+#if canImport(ObjectiveC)
+    private let _mapTable: NSMapTable<Owner, File> = .weakToStrongObjects()
+#else
+    private var _mapTable = WeakKeyStrongValueMap<Owner, File>()
+#endif
+
+    init() {}
+
+    @inline(__always)
+    @_optimize(speed)
+    func fileHandle(
+        for owner: Owner,
+        initialize: () -> File
+    ) -> File {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let fileHandle = _mapTable.object(forKey: owner) {
+            return fileHandle
+        } else {
+            let fileHandle = initialize()
+            _mapTable.setObject(fileHandle, forKey: owner)
+            return fileHandle
+        }
+    }
+}

--- a/Sources/MachOObjCSection/Util/WeakKeyStrongValueMap.swift
+++ b/Sources/MachOObjCSection/Util/WeakKeyStrongValueMap.swift
@@ -1,0 +1,40 @@
+//
+//  WeakKeyStrongValueMap.swift
+//  MachOObjCSection
+//
+//  Created by p-x9 on 2026/02/08
+//  
+//
+
+import Foundation
+
+#if !canImport(ObjectiveC)
+final class WeakBox<Value: AnyObject> {
+    weak var value: Value?
+    let id: ObjectIdentifier
+
+    init(_ value: Value) {
+        self.value = value
+        self.id = ObjectIdentifier(value)
+    }
+}
+
+struct WeakKeyStrongValueMap<Key: AnyObject, Value> {
+    private var storage: [ObjectIdentifier: (key: WeakBox<Key>, value: Value)] = [:]
+
+    mutating func object(forKey key: Key) -> Value? {
+        cleanupIfNeeded()
+        return storage[ObjectIdentifier(key)]?.value
+    }
+
+    mutating func setObject(_ value: Value, forKey key: Key) {
+        cleanupIfNeeded()
+        let box = WeakBox(key)
+        storage[box.id] = (box, value)
+    }
+
+    private mutating func cleanupIfNeeded() {
+        storage = storage.filter { $0.value.key.value != nil }
+    }
+}
+#endif


### PR DESCRIPTION
Apply it to DyldCache, FullDyldCache, and MachOFile. Add a non-Objective-C fallback weak-key/strong-value map for handle storage.