### PR TITLE
Refactor ObjC method list helpers

### DIFF
--- a/Sources/MachOObjCSection/Model/Method/ObjCMethodList.swift
+++ b/Sources/MachOObjCSection/Model/Method/ObjCMethodList.swift
@@ -181,25 +181,7 @@ extension ObjCMethodList {
                 swapHandler: nil
             )
             return sequence
-                .map {
-                    let imp: UInt64 = if let cache = machO.cache, $0.imp > 0 {
-                        numericCast($0.imp) - cache.mainCacheHeader.sharedRegionStart
-                    } else {
-                        machO.fileOffset(of: numericCast($0.imp)) ?? 0
-                    }
-
-                    return ObjCMethod(
-                        name: resolveString(
-                            in: machO,
-                            forAddress: $0.name
-                        ),
-                        types: resolveString(
-                            in: machO,
-                            forAddress: $0.types
-                        ),
-                        imp: imp
-                    )
-                }
+                .map { pointerMethod($0, in: machO) }
         case .pointer:
             let sequence: DataSequence<ObjCMethod.Pointer32> = fileHandle.readDataSequence(
                 offset: fileOffset,
@@ -207,25 +189,7 @@ extension ObjCMethodList {
                 swapHandler: nil
             )
             return sequence
-                .map {
-                    let imp: UInt64 = if let cache = machO.cache, $0.imp > 0 {
-                        numericCast($0.imp) - cache.mainCacheHeader.sharedRegionStart
-                    } else {
-                        machO.fileOffset(of: numericCast($0.imp)) ?? 0
-                    }
-
-                    return ObjCMethod(
-                        name: resolveString(
-                            in: machO,
-                            forAddress: numericCast($0.name)
-                        ),
-                        types: resolveString(
-                            in: machO,
-                            forAddress: numericCast($0.types)
-                        ),
-                        imp: imp
-                    )
-                }
+                .map { pointerMethod($0, in: machO) }
 
         case .relativeIndirect:
             let sequence: DataSequence<ObjCMethod.RelativeInDirect> = fileHandle.readDataSequence(
@@ -238,36 +202,12 @@ extension ObjCMethodList {
                 .map {
                     let offset = numericCast(offset) + $0 * size
                     let fileOffset = numericCast(fileOffset) + $0 * size
-
-                    let namePointerOffset = resolvedOffset(
-                        base: numericCast(fileOffset),
-                        relative: $1.name.offset
-                    ) ?? 0
-                    let nameAddress: UInt64 = (try? fileHandle.read(
-                        offset: numericCast(namePointerOffset),
-                        as: UInt64.self
-                    )) ?? 0
-                    let types = resolvedOffset(
-                        base: numericCast(fileOffset),
-                        relative: $1.types.offset,
-                        adjustment: 4
-                    ) ?? 0
-
-                    let imp = resolvedOffset(
-                        base: numericCast(offset),
-                        relative: $1.imp.offset,
-                        adjustment: 8
-                    ) ?? 0
-
-                    return ObjCMethod(
-                        name: resolveString(
-                            in: machO,
-                            forAddress: nameAddress
-                        ),
-                        types: fileHandle.readString(
-                            offset: numericCast(types)
-                        ) ?? "",
-                        imp: imp
+                    return indirectMethod(
+                        $1,
+                        in: machO,
+                        fileHandle: fileHandle,
+                        entryOffset: numericCast(offset),
+                        fileOffset: numericCast(fileOffset)
                     )
                 }
 
@@ -317,6 +257,91 @@ extension ObjCMethodList {
 }
 
 extension ObjCMethodList {
+    private func pointerMethod(
+        _ pointer: ObjCMethod.Pointer64,
+        in machO: MachOFile
+    ) -> ObjCMethod {
+        let imp: UInt64 = if let cache = machO.cache, pointer.imp > 0 {
+            numericCast(pointer.imp) - cache.mainCacheHeader.sharedRegionStart
+        } else {
+            machO.fileOffset(of: numericCast(pointer.imp)) ?? 0
+        }
+
+        return ObjCMethod(
+            name: resolveString(
+                in: machO,
+                forAddress: pointer.name
+            ),
+            types: resolveString(
+                in: machO,
+                forAddress: pointer.types
+            ),
+            imp: imp
+        )
+    }
+
+    private func pointerMethod(
+        _ pointer: ObjCMethod.Pointer32,
+        in machO: MachOFile
+    ) -> ObjCMethod {
+        let imp: UInt64 = if let cache = machO.cache, pointer.imp > 0 {
+            numericCast(pointer.imp) - cache.mainCacheHeader.sharedRegionStart
+        } else {
+            machO.fileOffset(of: numericCast(pointer.imp)) ?? 0
+        }
+
+        return ObjCMethod(
+            name: resolveString(
+                in: machO,
+                forAddress: numericCast(pointer.name)
+            ),
+            types: resolveString(
+                in: machO,
+                forAddress: numericCast(pointer.types)
+            ),
+            imp: imp
+        )
+    }
+
+    private func indirectMethod(
+        _ relativeIndirect: ObjCMethod.RelativeInDirect,
+        in machO: MachOFile,
+        fileHandle: MachOFile.File,
+        entryOffset: UInt64,
+        fileOffset: UInt64
+    ) -> ObjCMethod {
+        let namePointerOffset = resolvedOffset(
+            base: fileOffset,
+            relative: relativeIndirect.name.offset
+        ) ?? 0
+        let nameAddress: UInt64 = (try? fileHandle.read(
+            offset: numericCast(namePointerOffset),
+            as: UInt64.self
+        )) ?? 0
+        let types = resolvedOffset(
+            base: fileOffset,
+            relative: relativeIndirect.types.offset,
+            adjustment: 4
+        ) ?? 0
+
+        let imp = resolvedOffset(
+            base: entryOffset,
+            relative: relativeIndirect.imp.offset,
+            adjustment: 8
+        ) ?? 0
+
+        return ObjCMethod(
+            name: resolveString(
+                in: machO,
+                forAddress: nameAddress
+            ),
+            types: fileHandle.readString(
+                offset: numericCast(types)
+            ) ?? "",
+            imp: imp
+        )
+    }
+
     private func directMethod(
         _ relativeDirect: ObjCMethod.RelativeDirect,
         in machO: MachOFile,

--- a/Sources/MachOObjCSection/Model/Method/ObjCMethodList.swift
+++ b/Sources/MachOObjCSection/Model/Method/ObjCMethodList.swift
@@ -386,7 +386,9 @@ extension ObjCMethodList {
             imp: imp
         )
     }
+}
 
+extension ObjCMethodList {
     private func resolvedOffset<Offset: BinaryInteger>(
         base: UInt64,
         relative: Offset,

--- a/Sources/MachOObjCSection/Model/Method/ObjCMethodList.swift
+++ b/Sources/MachOObjCSection/Model/Method/ObjCMethodList.swift
@@ -280,27 +280,15 @@ extension ObjCMethodList {
 
             let size = MemoryLayout<ObjCMethod.RelativeDirect>.size
             let nameOffsetInCache = machO.relativeMethodSelectorBaseAddressOffset ?? 0
-
             return sequence.enumerated()
                 .map {
                     let offset = numericCast(offset) + $0 * size
-                    let _name = resolvedOffset(
-                        base: nameOffsetInCache,
-                        relative: $1.name.offset
-                    ) ?? 0
-                    let _types: UInt64 = numericCast(offset + numericCast($1.types.offset)) + 4
-                    let imp: UInt64 = numericCast(offset + numericCast($1.imp.offset)) + 8
-
-                    return ObjCMethod(
-                        name: resolveString(
-                            in: machO,
-                            forOffset: _name
-                        ),
-                        types: resolveString(
-                            in: machO,
-                            forOffset: _types
-                        ),
-                        imp: imp
+                    return directMethod(
+                        $1,
+                        in: machO,
+                        entryOffset: numericCast(offset),
+                        nameBaseOffset: nameOffsetInCache,
+                        typeBaseOffset: nil
                     )
                 }
 
@@ -313,32 +301,15 @@ extension ObjCMethodList {
 
             let size = MemoryLayout<ObjCMethod.RelativeDirect>.size
             let nameOffsetInCache = machO.relativeMethodSelectorBaseAddressOffset ?? 0
-            let typeOffsetInCache = nameOffsetInCache
-
             return sequence.enumerated()
                 .map {
                     let offset = numericCast(offset) + $0 * size
-                    let _name = resolvedOffset(
-                        base: nameOffsetInCache,
-                        relative: $1.name.offset
-                    ) ?? 0
-                    let _types = resolvedOffset(
-                        base: numericCast(offset),
-                        relative: $1.types.offset,
-                        adjustment: 4
-                    ) ?? 0
-                    let imp: UInt64 = numericCast(offset + numericCast($1.imp.offset)) + 8
-
-                    return ObjCMethod(
-                        name: resolveString(
-                            in: machO,
-                            forOffset: _name
-                        ),
-                        types: resolveString(
-                            in: machO,
-                            forOffset: typeOffsetInCache + _types
-                        ),
-                        imp: imp
+                    return directMethod(
+                        $1,
+                        in: machO,
+                        entryOffset: numericCast(offset),
+                        nameBaseOffset: nameOffsetInCache,
+                        typeBaseOffset: nameOffsetInCache // NOTE: offset from selector
                     )
                 }
         }
@@ -346,6 +317,51 @@ extension ObjCMethodList {
 }
 
 extension ObjCMethodList {
+    private func directMethod(
+        _ relativeDirect: ObjCMethod.RelativeDirect,
+        in machO: MachOFile,
+        entryOffset: UInt64,
+        nameBaseOffset: UInt64,
+        typeBaseOffset: UInt64?
+    ) -> ObjCMethod {
+        let nameOffset = resolvedOffset(
+            base: nameBaseOffset,
+            relative: relativeDirect.name.offset
+        ) ?? 0
+
+        let typesOffset: UInt64
+        if let typeBaseOffset {
+            typesOffset = resolvedOffset(
+                base: typeBaseOffset,
+                relative: relativeDirect.types.offset
+            ) ?? 0
+        } else {
+            typesOffset = resolvedOffset(
+                base: entryOffset,
+                relative: relativeDirect.types.offset,
+                adjustment: 4
+            ) ?? 0
+        }
+
+        let imp = resolvedOffset(
+            base: entryOffset,
+            relative: relativeDirect.imp.offset,
+            adjustment: 8
+        ) ?? 0
+
+        return ObjCMethod(
+            name: resolveString(
+                in: machO,
+                forOffset: nameOffset
+            ),
+            types: resolveString(
+                in: machO,
+                forOffset: typesOffset
+            ),
+            imp: imp
+        )
+    }
+
     private func resolvedOffset<Offset: BinaryInteger>(
         base: UInt64,
         relative: Offset,

--- a/Sources/MachOObjCSection/Model/Method/ObjCMethodList.swift
+++ b/Sources/MachOObjCSection/Model/Method/ObjCMethodList.swift
@@ -239,23 +239,31 @@ extension ObjCMethodList {
                     let offset = numericCast(offset) + $0 * size
                     let fileOffset = numericCast(fileOffset) + $0 * size
 
-                    var name = ""
-                    if let (fileHandle, fileOffset) = machO.fileHandleAndOffset(
-                        forAddress: try! fileHandle.read(
-                            offset: numericCast(fileOffset) + numericCast($1.name.offset)
-                        )
-                    ) {
-                        name = fileHandle.readString(
-                            offset: fileOffset
-                        ) ?? ""
-                    }
+                    let namePointerOffset = resolvedOffset(
+                        base: numericCast(fileOffset),
+                        relative: $1.name.offset
+                    ) ?? 0
+                    let nameAddress: UInt64 = (try? fileHandle.read(
+                        offset: numericCast(namePointerOffset),
+                        as: UInt64.self
+                    )) ?? 0
+                    let types = resolvedOffset(
+                        base: numericCast(fileOffset),
+                        relative: $1.types.offset,
+                        adjustment: 4
+                    ) ?? 0
 
-                    let types: Int64 = numericCast(fileOffset) + numericCast($1.types.offset) + 4
-
-                    let imp: UInt64 = numericCast(offset + numericCast($1.imp.offset)) + 8
+                    let imp = resolvedOffset(
+                        base: numericCast(offset),
+                        relative: $1.imp.offset,
+                        adjustment: 8
+                    ) ?? 0
 
                     return ObjCMethod(
-                        name: name,
+                        name: resolveString(
+                            in: machO,
+                            forAddress: nameAddress
+                        ),
                         types: fileHandle.readString(
                             offset: numericCast(types)
                         ) ?? "",
@@ -315,8 +323,9 @@ extension ObjCMethodList {
                         relative: $1.name.offset
                     ) ?? 0
                     let _types = resolvedOffset(
-                        base: typeOffsetInCache,
-                        relative: offset + numericCast(UInt32(bitPattern: $1.types.offset)) + 4
+                        base: numericCast(offset),
+                        relative: $1.types.offset,
+                        adjustment: 4
                     ) ?? 0
                     let imp: UInt64 = numericCast(offset + numericCast($1.imp.offset)) + 8
 
@@ -327,7 +336,7 @@ extension ObjCMethodList {
                         ),
                         types: resolveString(
                             in: machO,
-                            forOffset: _types
+                            forOffset: typeOffsetInCache + _types
                         ),
                         imp: imp
                     )

--- a/Sources/MachOObjCSection/Model/Method/ObjCMethodList.swift
+++ b/Sources/MachOObjCSection/Model/Method/ObjCMethodList.swift
@@ -182,19 +182,6 @@ extension ObjCMethodList {
             )
             return sequence
                 .map {
-                    var name = ""
-                    if let (fileHandle, fileOffset) = machO.fileHandleAndOffset(forAddress: $0.name) {
-                        name = fileHandle.readString(
-                            offset: fileOffset
-                        ) ?? ""
-                    }
-                    var types = ""
-                    if let (fileHandle, fileOffset) = machO.fileHandleAndOffset(forAddress: $0.types) {
-                        types = fileHandle.readString(
-                            offset: fileOffset
-                        ) ?? ""
-                    }
-
                     let imp: UInt64 = if let cache = machO.cache, $0.imp > 0 {
                         numericCast($0.imp) - cache.mainCacheHeader.sharedRegionStart
                     } else {
@@ -202,8 +189,14 @@ extension ObjCMethodList {
                     }
 
                     return ObjCMethod(
-                        name: name,
-                        types: types,
+                        name: resolveString(
+                            in: machO,
+                            forAddress: $0.name
+                        ),
+                        types: resolveString(
+                            in: machO,
+                            forAddress: $0.types
+                        ),
                         imp: imp
                     )
                 }
@@ -215,19 +208,6 @@ extension ObjCMethodList {
             )
             return sequence
                 .map {
-                    var name = ""
-                    if let (fileHandle, fileOffset) = machO.fileHandleAndOffset(forAddress: numericCast($0.name)) {
-                        name = fileHandle.readString(
-                            offset: fileOffset
-                        ) ?? ""
-                    }
-                    var types = ""
-                    if let (fileHandle, fileOffset) = machO.fileHandleAndOffset(forAddress: numericCast($0.types)) {
-                        types = fileHandle.readString(
-                            offset: fileOffset
-                        ) ?? ""
-                    }
-
                     let imp: UInt64 = if let cache = machO.cache, $0.imp > 0 {
                         numericCast($0.imp) - cache.mainCacheHeader.sharedRegionStart
                     } else {
@@ -235,8 +215,14 @@ extension ObjCMethodList {
                     }
 
                     return ObjCMethod(
-                        name: name,
-                        types: types,
+                        name: resolveString(
+                            in: machO,
+                            forAddress: numericCast($0.name)
+                        ),
+                        types: resolveString(
+                            in: machO,
+                            forAddress: numericCast($0.types)
+                        ),
                         imp: imp
                     )
                 }
@@ -290,27 +276,22 @@ extension ObjCMethodList {
             return sequence.enumerated()
                 .map {
                     let offset = numericCast(offset) + $0 * size
-                    let _name: Int64 = numericCast($1.name.offset)
+                    let _name = resolvedOffset(
+                        base: nameOffsetInCache,
+                        relative: $1.name.offset
+                    ) ?? 0
                     let _types: UInt64 = numericCast(offset + numericCast($1.types.offset)) + 4
                     let imp: UInt64 = numericCast(offset + numericCast($1.imp.offset)) + 8
 
-                    var name = ""
-                    if let (fileHandle, fileOffset) = machO.fileHandleAndOffset(forOffset: nameOffsetInCache + numericCast(_name)) {
-                        name = fileHandle.readString(
-                            offset: fileOffset
-                        ) ?? ""
-                    }
-
-                    var types = ""
-                    if let (fileHandle, fileOffset) = machO.fileHandleAndOffset(forOffset: numericCast(_types)) {
-                        types = fileHandle.readString(
-                            offset: fileOffset
-                        ) ?? ""
-                    }
-
                     return ObjCMethod(
-                        name: name,
-                        types: types,
+                        name: resolveString(
+                            in: machO,
+                            forOffset: _name
+                        ),
+                        types: resolveString(
+                            in: machO,
+                            forOffset: _types
+                        ),
                         imp: imp
                     )
                 }
@@ -329,32 +310,67 @@ extension ObjCMethodList {
             return sequence.enumerated()
                 .map {
                     let offset = numericCast(offset) + $0 * size
-                    let _name: Int64 = numericCast($1.name.offset)
-                    let _types: UInt64 = numericCast(
-                        offset + numericCast(UInt32(bitPattern: $1.types.offset))
-                    ) + 4
+                    let _name = resolvedOffset(
+                        base: nameOffsetInCache,
+                        relative: $1.name.offset
+                    ) ?? 0
+                    let _types = resolvedOffset(
+                        base: typeOffsetInCache,
+                        relative: offset + numericCast(UInt32(bitPattern: $1.types.offset)) + 4
+                    ) ?? 0
                     let imp: UInt64 = numericCast(offset + numericCast($1.imp.offset)) + 8
 
-                    var name = ""
-                    if let (fileHandle, fileOffset) = machO.fileHandleAndOffset(forOffset: nameOffsetInCache + numericCast(_name)) {
-                        name = fileHandle.readString(
-                            offset: fileOffset
-                        ) ?? ""
-                    }
-
-                    var types = ""
-                    if let (fileHandle, fileOffset) = machO.fileHandleAndOffset(forOffset: typeOffsetInCache + numericCast(_types)) {
-                        types = fileHandle.readString(
-                            offset: fileOffset
-                        ) ?? ""
-                    }
-
                     return ObjCMethod(
-                        name: name,
-                        types: types,
+                        name: resolveString(
+                            in: machO,
+                            forOffset: _name
+                        ),
+                        types: resolveString(
+                            in: machO,
+                            forOffset: _types
+                        ),
                         imp: imp
                     )
                 }
         }
+    }
+}
+
+extension ObjCMethodList {
+    private func resolvedOffset<Offset: BinaryInteger>(
+        base: UInt64,
+        relative: Offset,
+        adjustment: UInt64 = 0
+    ) -> UInt64? {
+        guard let base = Int64(exactly: base),
+              let relative = Int64(exactly: relative),
+              let adjustment = Int64(exactly: adjustment) else {
+            return nil
+        }
+        let resolved = base + relative + adjustment
+        guard resolved >= 0 else {
+            return nil
+        }
+        return UInt64(resolved)
+    }
+
+    private func resolveString(
+        in machO: MachOFile,
+        forAddress address: UInt64
+    ) -> String {
+        guard let (fileHandle, fileOffset) = machO.fileHandleAndOffset(forAddress: address) else {
+            return ""
+        }
+        return fileHandle.readString(offset: fileOffset) ?? ""
+    }
+
+    private func resolveString(
+        in machO: MachOFile,
+        forOffset offset: UInt64
+    ) -> String {
+        guard let (fileHandle, fileOffset) = machO.fileHandleAndOffset(forOffset: offset) else {
+            return ""
+        }
+        return fileHandle.readString(offset: fileOffset) ?? ""
     }
 }


### PR DESCRIPTION
Split ObjC method lookup into small helpers for pointer, indirect, and direct cases.